### PR TITLE
Quick improvements to cli/yargs/countEntriesIndirectory example

### DIFF
--- a/cli/yargs/countEntriesInDirectory/README.md
+++ b/cli/yargs/countEntriesInDirectory/README.md
@@ -1,18 +1,20 @@
 # countEntriesInDirectory
 
-This is a CLI built with [yargs](https://www.npmjs.com/package/yargs) that searches the directory (path) passed to it and then spits out how many entries (files and directories) are within _that directory_. It does not recursively search additional directories within it.
+This is a CLI built with [yargs](https://www.npmjs.com/package/yargs) that searches the directory (path) passed to it and then spits out how many entries (files and directories) are within _that directory_. It can recursively search additional directories within it.
 
 ## Usage
 
 Here is the output of running `node bin/cli.js -h` from the `countEntriesInDirectory` directory:
 
 ```bash
-Usage: cli.js --directory=[path to a directory]
+Usage: cli.js --directory=[path to a directory] [--recurse]
 
 Options:
   --help           Show help                                           [boolean]
   --version        Show version number                                 [boolean]
-  --directory, -d  the directory to count files within.               [required]
+  -d, --directory  The directory to count files within.      [string] [required]
+  -r, --recurse    Should we recurse on child directories?
+                                                      [boolean] [default: false]
 ```
 
 ### As a Local Project

--- a/cli/yargs/countEntriesInDirectory/bin/cli.js
+++ b/cli/yargs/countEntriesInDirectory/bin/cli.js
@@ -5,19 +5,19 @@ const countEntries = require('../lib/countEntries') // requires our code that do
 const log = require('../lib/log') // tiny tool we built to log output that's async/await
 
 const yargs = require('yargs')
-  .usage('Usage: $0 --directory=[path to a directory] --recurse') // defines what will be shown when the command errors out
+  .usage('Usage: $0 --directory=[path to a directory] [--recurse]') // defines what will be shown when the command errors out
   .options({
     d: {
       alias: 'directory',
       demandOption: true,
-      describe: 'the directory to count files within.',
+      describe: 'The directory to count files within.',
       type: 'string'
     },
     r: {
       alias: 'recurse',
       demandOption: false,
       default: false,
-      describe: 'should we recurse on child directories?',
+      describe: 'Should we recurse on child directories?',
       type: 'boolean'
     }
   })

--- a/cli/yargs/countEntriesInDirectory/bin/cli.js
+++ b/cli/yargs/countEntriesInDirectory/bin/cli.js
@@ -5,10 +5,22 @@ const countEntries = require('../lib/countEntries') // requires our code that do
 const log = require('../lib/log') // tiny tool we built to log output that's async/await
 
 const yargs = require('yargs')
-  .usage('Usage: $0 --directory=[path to a directory]') // defines what will be shown when the command errors out
-  .demand('directory') // makes the `--directory` flag required
-  .alias('directory', 'd') // aliases `--directory` to `-d`
-  .describe('directory', 'the directory to count files within.') // describes what we're looking for from `--directory` for users when they write `--help`
+  .usage('Usage: $0 --directory=[path to a directory] --recurse') // defines what will be shown when the command errors out
+  .options({
+    d: {
+      alias: 'directory',
+      demandOption: true,
+      describe: 'the directory to count files within.',
+      type: 'string'
+    },
+    r: {
+      alias: 'recurse',
+      demandOption: false,
+      default: false,
+      describe: 'should we recurse on child directories?',
+      type: 'boolean'
+    }
+  })
   .argv
 
-log(countEntries(yargs.directory))
+log(countEntries(yargs.directory, yargs.recurse))

--- a/cli/yargs/countEntriesInDirectory/lib/countEntries.js
+++ b/cli/yargs/countEntriesInDirectory/lib/countEntries.js
@@ -1,14 +1,24 @@
 const fs = require('fs').promises // use the promisified fs module
 const path = require('path')
 
-let files = 0 // initiate count to add to
-
-async function countFiles (folderPath) {
+async function countFiles (folderPath, doRecurse) {
+  let files = 0 // initiate count to add to
   try {
+    const childPaths = []
     const usablePath = path.resolve(folderPath) // get the full path
-    const contents = await fs.readdir(usablePath) // read the directory
+    const contents = await fs.readdir(usablePath, { withFileTypes: true }) // read the directory
 
-    contents.forEach(() => { files = files + 1 }) // add 1 for every file in the directory
+    contents.forEach((dirent) => {
+      files = files + 1 // add 1 for every file in the directory
+
+      if (doRecurse && dirent.isDirectory()) {
+        childPaths.push(path.join(usablePath, dirent.name))
+      }
+    })
+
+    for (const childPath of childPaths) {
+      files += await countFiles(childPath)
+    }
 
     return files
   } catch (error) { // this will most likely be triggered if `folderPath` is not a real path.

--- a/cli/yargs/countEntriesInDirectory/lib/countEntries.test.js
+++ b/cli/yargs/countEntriesInDirectory/lib/countEntries.test.js
@@ -5,7 +5,14 @@ describe('test `countFiles()` successful runs', () => {
     const directory = __dirname // this will be `lib`
     const entries = await countEntries(directory)
 
-    expect(entries).toBe(4)
+    expect(entries).toBe(5)
+  })
+
+  test('Test entries recursively in cli/yargs/countEntriesInDirectory', async () => {
+    const directory = __dirname // this will be `lib`
+    const entries = await countEntries(directory, true)
+
+    expect(entries).toBe(6)
   })
 })
 

--- a/cli/yargs/countEntriesInDirectory/lib/countEntries.test.js
+++ b/cli/yargs/countEntriesInDirectory/lib/countEntries.test.js
@@ -8,3 +8,15 @@ describe('test `countFiles()` successful runs', () => {
     expect(entries).toBe(4)
   })
 })
+
+describe('test `countFiles()` throws error', () => {
+  test('Call cli/yargs/countEntriesInDirectory with invalid arg', async () => {
+    const directory = 'foo'
+    expect.assertions(1)
+    try {
+      await countEntries(directory)
+    } catch (error) {
+      expect(error.toString()).toMatch(`Error: It seems there was a problem. Are you sure ${directory} a valid path?`)
+    }
+  })
+})

--- a/cli/yargs/countEntriesInDirectory/lib/log.test.js
+++ b/cli/yargs/countEntriesInDirectory/lib/log.test.js
@@ -18,6 +18,17 @@ describe('test `log()` successful runs', () => {
   })
 })
 
+describe('test `log()` throws error', () => {
+  test('expect `log()` to pass an error', async () => {
+    expect.assertions(1)
+    try {
+      await log(awaitedMethodThrowsError())
+    } catch (error) {
+      expect(error.toString()).toMatch('Error: This is an expected error')
+    }
+  })
+})
+
 async function awaitedMethodWithoutAPromise (anyValue) {
   return anyValue
 }
@@ -26,4 +37,8 @@ async function awaitedMethodWithAPromise (anyValue) {
   const valueToReturn = await awaitedMethodWithoutAPromise(anyValue) * 2
 
   return valueToReturn
+}
+
+async function awaitedMethodThrowsError () {
+  throw new Error('This is an expected error')
 }

--- a/cli/yargs/countEntriesInDirectory/lib/test-data/testfile.txt
+++ b/cli/yargs/countEntriesInDirectory/lib/test-data/testfile.txt
@@ -1,0 +1,1 @@
+This is for testing the recursive option

--- a/cli/yargs/countEntriesInDirectory/package.json
+++ b/cli/yargs/countEntriesInDirectory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "count-entries-in-directory",
   "version": "1.1.0",
-  "description": "This is a CLI built with [yargs](https://www.npmjs.com/package/yargs) that searches the directory (path) passed to it and then spits out how many entries (files and directories) are within _that directory_. It does not recursively search additional directories within it.",
+  "description": "This is a CLI built with [yargs](https://www.npmjs.com/package/yargs) that searches the directory (path) passed to it and then spits out how many entries (files and directories) are within _that directory_. It can recursively search additional directories within it.",
   "main": "index.js",
   "bin": {
     "countEntriesInDirectory": "./bin/cli.js"

--- a/cli/yargs/countEntriesInDirectory/package.json
+++ b/cli/yargs/countEntriesInDirectory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "count-entries-in-directory",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "This is a CLI built with [yargs](https://www.npmjs.com/package/yargs) that searches the directory (path) passed to it and then spits out how many entries (files and directories) are within _that directory_. It does not recursively search additional directories within it.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
This code is forked from https://github.com/nodejs/examples

Here are some quick improvements to the **cli/yargs/countEntriesInDirectory** example:
- test: Extend coverage to 100% (cover error cases)
- feat: Add option to recurse on child directories

